### PR TITLE
Enable optimizations

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -14,7 +14,6 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
             )

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,3 @@
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 kotlin.code.style=official
-
-# TODO(robinlinden): Migrate away from the below flags.
-# See: https://developer.android.com/build/releases/agp-9-0-0-release-notes#android-gradle-plugin-behavior-changes
-android.newDsl=false

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -19,7 +19,8 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
             )

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -17,7 +17,8 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
             )


### PR DESCRIPTION
I could've sworn removing `android.newDsl=false` made Android Studio angry, but maybe it was before we nuked some of the other deprecated behaviour..